### PR TITLE
remove 'n' from the name flag

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,3 +15,11 @@ linters:
 linters-settings:
   gofmt:
     simplify: true
+issues:
+  exclude-dirs:
+    - '.*pkg/mod.*'
+    - '.*go/.*'
+    - '.*Cellar.*'             # Skip Homebrew Go installation directory
+    - '.*libexec.*'
+  exclude-files:
+    - '.*toolchain@.*'

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ print_home:
 
 
 local.deploy: local.build ## Deploys locally built Helm plugin
-  @rm -rf ${HOME}/Library/helm/plugins/helm-kanvas-snapshot/bin/helm-kanvas-snapshot
+	@rm -rf ${HOME}/Library/helm/plugins/helm-kanvas-snapshot/bin/helm-kanvas-snapshot
 	@cp helm-images ${HOME}/Library/helm/plugins/helm-kanvas-snapshot/bin/helm-kanvas-snapshot
 
 

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ To install the Meshery Snapshot Helm Plugin, use the following steps:
 Once the plugin is installed, you can generate a snapshot using either a packaged or unpackaged Helm chart.
 
 ```bash
-helm helm-kanvas-snapshot -f <chart-URI> [-n <snapshot-name>] [-e <email>]
+helm helm-kanvas-snapshot -f <chart-URI> [--name <snapshot-name>] [-e <email>]
 ```
 
 - **`-f`**, **`--file`**: (required) path or URL to the Helm chart (required).
-- **`-n`**, **`--name`**: (optional) name for the snapshot. If not provided, a name will be auto-generated based on the chart name.
+- **`--name`**: (optional) name for the snapshot. If not provided, a name will be auto-generated based on the chart name.
 - **`-e`, **`--email`**: (optional) email address to notify when snapshot is ready. If not provided, a link to the snapshot will be displayed in the terminal.
 
 **Example**
@@ -84,7 +84,7 @@ helm helm-kanvas-snapshot -f <chart-URI> [-n <snapshot-name>] [-e <email>]
 To generate a snapshot for a Helm chart located at `https://meshery.io/charts/v0.8.0-meshery.tar.gz`, you can use:
 
 ```bash
-helm helm-kanvas-snapshot -f https://meshery.io/charts/v0.8.0-meshery.tar.gz -n meshery-chart
+helm helm-kanvas-snapshot -f https://meshery.io/charts/v0.8.0-meshery.tar.gz --name meshery-chart
 ```
 
 ## Contributing
@@ -128,7 +128,7 @@ helm plugin install kanvas-snapshot
 Once the plugin is built, you can test it locally. For example, to generate a snapshot for a Helm chart, run the following command:
 
 ```bash
-helm helm-kanvas-snapshot -f https://meshery.io/charts/v0.8.0-meshery.tar.gz -n meshery-chart
+helm helm-kanvas-snapshot -f https://meshery.io/charts/v0.8.0-meshery.tar.gz --name meshery-chart
 ```
 
 This command will trigger the snapshot generation process. If everything is set up correctly, you should see a visual snapshot URL or receive the snapshot via email, depending on the options you specified.

--- a/cmd/kanvas-snapshot/cmd.go
+++ b/cmd/kanvas-snapshot/cmd.go
@@ -39,7 +39,6 @@ var generateKanvasSnapshotCmd = &cobra.Command{
 	Short: "Generate a Kanvas snapshot using a Helm chart",
 	Long: `Generate a Kanvas snapshot by providing a Helm chart URI.
 
-	    helm kanvas-snapshot -f <helm-chart-uri> -e[email] --name[name]
 		This command allows you to generate a snapshot in Meshery using a Helm chart.
 
 		Example usage:

--- a/cmd/kanvas-snapshot/cmd.go
+++ b/cmd/kanvas-snapshot/cmd.go
@@ -48,7 +48,7 @@ var generateKanvasSnapshotCmd = &cobra.Command{
 		Flags:
 		-f, --file  string	URI to Helm chart (required)
 		-e, --email string	email address to notify when snapshot is ready (required)
-		    --name  string	(optional name for the Meshery design
+		    --name  string	(optional) name for the Meshery design
 		-h			Help for Helm Kanvas Snapshot plugin`,
 
 	RunE: func(_ *cobra.Command, _ []string) error {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/meshery/helm-kanvas-snapshot
 
-go 1.21.8
+go 1.23
+
 toolchain go1.23.4
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/meshery/helm-kanvas-snapshot
 
-go 1.21.8
+go 1.23
 
 toolchain go1.23.4
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/meshery/helm-kanvas-snapshot
 
-go 1.23
+go 1.21.8
 
 toolchain go1.23.4
 

--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -15,7 +15,6 @@ var (
 	ErrUnexpectedResponseCodeCode   = "kanvas-snapshot-906"
 	ErrRequiredFieldNotProvidedCode = "kanvas-snapshot-907"
 	ErrInvalidEmailFormatCode       = "kanvas-snapshot-908"
-	ErrErrInvalidFlagCode           = "kanvas-snapshot-909"
 )
 
 func ErrInvalidChartURI(err error) error {
@@ -87,14 +86,5 @@ func ErrInvalidEmailFormat(email string) error {
 		[]string{fmt.Sprintf("The provided email '%s' is not a valid email format.", email)},
 		[]string{"The email provided for the Kanvas snapshot request is not in the correct format."},
 		[]string{"Ensure the email address follows the correct format (e.g., user@example.com)."},
-	)
-}
-
-func ErrInvalidFlag(err error, usage string) error {
-	return errors.New(ErrCreatingMesheryDesignCode, errors.Alert,
-		[]string{"%w\n\n%s", err.Error(), usage},
-		[]string{err.Error()},
-		[]string{"Meshery Design creation failed due to an error."},
-		[]string{"Check Meshery API connection and ensure the payload is correct."},
 	)
 }

--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -15,6 +15,7 @@ var (
 	ErrUnexpectedResponseCodeCode   = "kanvas-snapshot-906"
 	ErrRequiredFieldNotProvidedCode = "kanvas-snapshot-907"
 	ErrInvalidEmailFormatCode       = "kanvas-snapshot-908"
+	ErrErrInvalidFlagCode           = "kanvas-snapshot-909"
 )
 
 func ErrInvalidChartURI(err error) error {
@@ -86,5 +87,14 @@ func ErrInvalidEmailFormat(email string) error {
 		[]string{fmt.Sprintf("The provided email '%s' is not a valid email format.", email)},
 		[]string{"The email provided for the Kanvas snapshot request is not in the correct format."},
 		[]string{"Ensure the email address follows the correct format (e.g., user@example.com)."},
+	)
+}
+
+func ErrInvalidFlag(err error, usage string) error {
+	return errors.New(ErrCreatingMesheryDesignCode, errors.Alert,
+		[]string{"%w\n\n%s", err.Error(), usage},
+		[]string{err.Error()},
+		[]string{"Meshery Design creation failed due to an error."},
+		[]string{"Check Meshery API connection and ensure the payload is correct."},
 	)
 }


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #
- Remove the name option with a single letter `-n`
- Update the asset location to point to the directory `action-assets/helm-plugin-assets`
- fix golangci checking some pakages from toochain by exclude external packages in golangci-lint

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
