### PR TITLE
[chore] Fix upload endpoint

### DIFF
--- a/cmd/kanvas-snapshot/cmd.go
+++ b/cmd/kanvas-snapshot/cmd.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -153,9 +152,7 @@ func CreateMesheryDesign(uri, name, email string) (string, error) {
 		return "", errors.ErrDecodingAPI(err)
 	}
 
-	sourceType := "Helm Chart"
-	encodedChartType := url.PathEscape(sourceType)
-	fullURL := fmt.Sprintf("%s/api/pattern/%s", MesheryAPIBaseURL, encodedChartType)
+	fullURL := fmt.Sprintf("%s/api/pattern/import", MesheryAPIBaseURL)
 
 	// Create the request
 	req, err := http.NewRequest("POST", fullURL, bytes.NewBuffer(payloadBytes))


### PR DESCRIPTION
**Notes for Reviewers**

Recent change in Meshery server https://github.com/meshery/meshery/pull/13445 to upload mechanism caused an issue with the plugin. Due to which an empty Kanvas is observed on uploading. Eg: https://raw.githubusercontent.com/layer5labs/meshery-extensions-packages/master/action-assets/helm-plugin-assets/cfa78ee2-f1f8-4d91-ac12-5dcf0aedf0d6.png


This PR updates the endpoint to the new endpoint /api/pattern/import. Now Helm Kanvas Plugin is able to successfully visualize https://raw.githubusercontent.com/layer5labs/meshery-extensions-packages/master/action-assets/helm-plugin-assets/c6370c80-3e32-4399-bdfb-78044f6c687e.png


This PR fixes #



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
