### PR TITLE
Update artifact repository ID to the correct Helm Kanvas Snapshot repo ID

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -9,7 +9,7 @@
 # when the hash of the last commit in the branch you set up changes. This does
 # NOT apply to ownership claim operations, which are processed immediately.
 #
-repositoryID: 1b4e2e51-4979-43c4-a164-c26426c196b2
+repositoryID: 38b16577-a167-4086-9395-0d693db1b590
 owners: # (optional, used to claim repository ownership)
   - name: meshery
     email: maintainers@meshery.io


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #

- Update Artifact Hub repo ID to the right Helm-kanvas-snapshot repo ID

<img width="636" alt="Screenshot 2025-02-12 at 18 35 22" src="https://github.com/user-attachments/assets/c332be0a-bec4-49a5-8aad-f659e8f304c0" />


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
